### PR TITLE
Set version 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-connectivity-status",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A ReactNative module to check Bluetooth and Location status on Android and iOS",
   "author": {
     "name": "Mattia Panzeri",


### PR DESCRIPTION
Hello!

Some time ago I've added the podspec file to this library (in this PR https://github.com/nearit/react-native-connectivity-status/pull/9) but we have not increased version because I thought that NPM will update current version - it doesn't :)

So, could I ask you to republish this lib with version 1.5.2, please?

If any edits are required from my side or I could help somehow just tell me how