### PR TITLE
Fix new NativeEventEmitter warnings on Android

### DIFF
--- a/android/src/main/java/com/nearit/connectivity/RNConnectivityStatusModule.java
+++ b/android/src/main/java/com/nearit/connectivity/RNConnectivityStatusModule.java
@@ -138,6 +138,16 @@ public class RNConnectivityStatusModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.  
+    }
+
+    @ReactMethod
+    public void removeListeners(int count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     /**
      * Private methods
      */


### PR DESCRIPTION
This PR fixes the warnings "new NativeEventEmitter() was called with a non-null argument without the required (...)" which occur on React Native 0.65+.

Related
- https://github.com/software-mansion/react-native-reanimated/pull/2316
- https://github.com/react-native-device-info/react-native-device-info/commit/3917f339207a5a2b05e3922f7489a0568dfde666